### PR TITLE
feat: list comprehension

### DIFF
--- a/rule2rego.ts
+++ b/rule2rego.ts
@@ -158,7 +158,8 @@ function emitRuleAnythingBut(context: Context): string {
 	}
 	if (ruleTest.type === PrimitiveNodeType.array) {
 		const val = ruleTest.text.slice(1, -1);
-		out += `${name} {\n\t{ ${val} } & { input${inputPath} } != { input${inputPath} }\n}`;
+		out += `${name} {\n\t{ ${val} } & { input${inputPath} } != { input${inputPath} }`;
+		out += `\n\tcount([match | v := input${inputPath}[_]; s := [ ${val} ][_]; s == v; match := v]) == 0\n}`;
 	}
 	if (ruleTest.type === PrimitiveNodeType.string) {
 		const val = unquote(ruleTest.text);

--- a/test/fixtures/anything-but-primitive-array-matching.json
+++ b/test/fixtures/anything-but-primitive-array-matching.json
@@ -4,7 +4,7 @@
       "sessionContext": {
         "sessionIssuer": {
           "arn": [
-            {"anything-but": ["arn:aws:iam:000000000000:role/bad-role"]}
+            {"anything-but": ["arn:aws:iam:000000000000:role/bad-role", "arn:aws:iam:000000000000:role/bad-role2"]}
           ]
         }
       }

--- a/test/fixtures/anything-but-primitive-array-matching/allows/event2.json
+++ b/test/fixtures/anything-but-primitive-array-matching/allows/event2.json
@@ -3,7 +3,7 @@
     "userIdentity": {
       "sessionContext": {
         "sessionIssuer": {
-          "arn": ["arn:aws:iam:000000000000:role/bad-role"]
+          "arn": ["arn:aws:iam:000000000000:role/good-role"]
         }
       }
     }

--- a/test/fixtures/anything-but-primitive-array-matching/allows/event3.json
+++ b/test/fixtures/anything-but-primitive-array-matching/allows/event3.json
@@ -3,7 +3,7 @@
     "userIdentity": {
       "sessionContext": {
         "sessionIssuer": {
-          "arn": ["arn:aws:iam:000000000000:role/bad-role"]
+          "arn": ["arn:aws:iam:000000000000:role/good-role", "arn:aws:iam:000000000000:role/great-role"]
         }
       }
     }

--- a/test/fixtures/anything-but-primitive-array-matching/denies/event1.json
+++ b/test/fixtures/anything-but-primitive-array-matching/denies/event1.json
@@ -3,7 +3,7 @@
     "userIdentity": {
       "sessionContext": {
         "sessionIssuer": {
-          "arn": ["arn:aws:iam:000000000000:role/bad-role"]
+          "arn": "arn:aws:iam:000000000000:role/bad-role"
         }
       }
     }

--- a/test/fixtures/anything-but-primitive-array-matching/denies/event3.json
+++ b/test/fixtures/anything-but-primitive-array-matching/denies/event3.json
@@ -3,7 +3,7 @@
     "userIdentity": {
       "sessionContext": {
         "sessionIssuer": {
-          "arn": ["arn:aws:iam:000000000000:role/bad-role"]
+          "arn": ["arn:aws:iam:000000000000:role/bad-role2", "arn:aws:iam:000000000000:role/good-role"]
         }
       }
     }

--- a/test/rule2rego.test.ts
+++ b/test/rule2rego.test.ts
@@ -19,7 +19,6 @@ describe("rule2rego tests", () => {
 			fixture.allows.forEach((input, i) => {
 				it(`allows: sample ${i}`, () => {
 					const result = fixture.policy.evaluate(input);
-					expect(result).not.toBeNull();
 					expect(result.length).toBe(1);
 					expect(result[0].result.allow).toBeTruthy();
 				});
@@ -27,9 +26,8 @@ describe("rule2rego tests", () => {
 			fixture.denies.forEach((input, i) => {
 				it(`denies: sample ${i}`, () => {
 					const result = fixture.policy.evaluate(input);
-					expect(result).not.toBeNull();
 					expect(result.length).toBe(1);
-					expect(result[0].result.deny).toBeFalsy();
+					expect(result[0].result.allow).toBeFalsy();
 				});
 			});
 		});


### PR DESCRIPTION
fixed negative test always passing
    
Added list comprehension of anything-but nested
    
When the value of the input is an array and nested in a prefix
list comprehension is required in order to see if any values
of the rule set are in the input set.