### PR TITLE
fix: exist fails on lists and boolean

### DIFF
--- a/test/fixtures/exists-matching.json
+++ b/test/fixtures/exists-matching.json
@@ -1,5 +1,6 @@
 {
   "detail": {
-    "state": [ { "exists": true  } ]
+    "state": [ { "exists": true  } ],
+    "error": [ { "exists": false  } ]
   }
 }

--- a/test/fixtures/exists-matching/allows/event2.json
+++ b/test/fixtures/exists-matching/allows/event2.json
@@ -1,0 +1,5 @@
+{
+  "detail": {
+    "state": false
+  }
+}

--- a/test/fixtures/exists-matching/denies/event2.json
+++ b/test/fixtures/exists-matching/denies/event2.json
@@ -1,0 +1,6 @@
+{
+  "detail": {
+    "state": "wrecked",
+    "error": "got"
+  }
+}

--- a/test/fixtures/exists-matching/denies/event3.json
+++ b/test/fixtures/exists-matching/denies/event3.json
@@ -1,0 +1,6 @@
+{
+  "detail": {
+    "state": "wrecked",
+    "error": false
+  }
+}


### PR DESCRIPTION
The old check looked if the key was set AND truthy. Meaning "key: false" would deny when it should allow. When I introduced the array colescence in the last PR I further broke the exist matcher by producing rego that failed on certain input formats but otherwise looked to perform correctly in these tests.

New change coalesces the value to an array, iterates the array, and checks if any index contains the key. A new helper function is added to these files as needed to check for the existence of the key rather than checking the key or value itself.